### PR TITLE
Fix configuration missing global section

### DIFF
--- a/bin/cepces-submit
+++ b/bin/cepces-submit
@@ -60,8 +60,8 @@ def main(global_overrides, krb5_overrides):
     else:
         try:
             # Load the configuration and instantiate a service.
-            config = Configuration.load(global_overrides,
-                                        krb5_overrides)
+            config = Configuration.load(global_overrides=global_overrides,
+                                        krb5_overrides=krb5_overrides)
             service = Service(config)
 
             # Call the operation.


### PR DESCRIPTION
These variables were being mistakenly passed as
the files and dirs parameters, which broke the
configuration.