### PR TITLE
added polling_interval for manually approved certificates

### DIFF
--- a/bin/cepces-submit
+++ b/bin/cepces-submit
@@ -83,12 +83,14 @@ if __name__ == '__main__':
         choices=['Anonymous', 'Kerberos',
                  'UsernamePassword', 'Certificate'],
         default='Kerberos')
+    parser.add_argument('--poll_interval',
+        help='Time in seconds before re-checking if the certificate has been issued')
     parser.add_argument('--keytab', help='Use the specified keytab')
     parser.add_argument('--principals',
         help='A list of principals to try when requesting a ticket')
     args = parser.parse_args()
     if args.server is not None:
-        g_overrides = { 'server': args.server, 'auth': args.auth }
+        g_overrides = { 'server': args.server, 'auth': args.auth, 'poll_interval': args.poll_interval }
         endpoint = 'https://%s/ADPolicyProvider_CEP_%s/service.svc/CEP' % \
                         (args.server, args.auth)
         g_overrides['endpoint'] = endpoint

--- a/cepces/certmonger/operation.py
+++ b/cepces/certmonger/operation.py
@@ -132,14 +132,15 @@ class Submit(Operation):
 
         # Output a "cookie" that can be used to later poll the status.
         print(
-            '{},{}'.format(
+            '{}\n{},{}'.format(
+                self._config.poll_interval,
                 result.request_id,
                 result.reference,
             ),
             file=self._out,
         )
 
-        return CertmongerResult.WAIT
+        return CertmongerResult.WAITMORE
 
 
 class Poll(Operation):
@@ -172,14 +173,15 @@ class Poll(Operation):
 
         # Output a "cookie" that can be used to later poll the status.
         print(
-            '{},{}'.format(
+            '{}\n{},{}'.format(
+                self._config.poll_interval,
                 result.request_id,
                 result.reference,
             ),
             file=self._out,
         )
 
-        return CertmongerResult.WAIT
+        return CertmongerResult.WAITMORE
 
 
 class Identify(Operation):

--- a/cepces/config.py
+++ b/cepces/config.py
@@ -55,13 +55,14 @@ class Configuration(Base):
         'Certificate': SOAPAuth.MessageCertificateAuthentication,
     }
 
-    def __init__(self, endpoint, endpoint_type, cas, auth):
+    def __init__(self, endpoint, endpoint_type, cas, auth, poll_interval):
         super().__init__()
 
         self._endpoint = endpoint
         self._endpoint_type = endpoint_type
         self._cas = cas
         self._auth = auth
+        self.pollInterval = poll_interval
 
     @property
     def endpoint(self):
@@ -82,6 +83,11 @@ class Configuration(Base):
     def auth(self):
         """Return the authentication method."""
         return self._auth
+
+    @property
+    def poll_interval(self):
+        """Return the poll interval."""
+        return self._poll_interval
 
     @classmethod
     def load(cls, files=None, dirs=None, global_overrides=None,
@@ -149,7 +155,7 @@ class Configuration(Base):
         section = parser['global']
 
         # Ensure certain required variables are present.
-        for var in ['endpoint', 'auth', 'type']:
+        for var in ['endpoint', 'auth', 'type', 'poll_interval']:
             if var not in section:
                 raise RuntimeError(
                     'Missing "{}/{}" variable in configuration.'.format(
@@ -171,8 +177,9 @@ class Configuration(Base):
         endpoint_type = section.get('type')
         authn = Configuration.AUTH_HANDLER_MAP[section['auth']](parser)
         cas = section.get('cas', True)
+        poll_interval = section.get('poll_interval')
 
         if cas == '':
             cas = False
 
-        return Configuration(endpoint, endpoint_type, cas, authn.handle())
+        return Configuration(endpoint, endpoint_type, cas, authn.handle(), poll_interval)

--- a/conf/cepces.conf.dist
+++ b/conf/cepces.conf.dist
@@ -45,6 +45,9 @@ endpoint=https://${server}/ADPolicyProvider_CEP_${auth}/service.svc/CEP
 # Default: <not defined>
 #cas=
 
+# Time in seconds before re-checking if the certificate has been issued
+poll_interval=3600
+
 [kerberos]
 # Use the specified keytab. If unspecified, the system default is used.
 #


### PR DESCRIPTION
certmonger by default rechecks if a certificate has been issued every 7 days  (doesnt seem user configurable from their documentation), this is a bit long and it would be nice if this was a configurable value.
This PR looks to implement a setting called poll_interval which makes use of the certmonger exit status 5.
Default for this PR has been set at 1 hour.


--------- secton from https://pagure.io/certmonger/blob/master/f/doc/helpers.txt
  * If the client should wait for a period of time, output a "cookie" value and
    exit with status 1.  The daemon will try again later at a time of its
    choosing (the default is currently 7 days).
  * If the client should wait for a specific period of time (for example, if
    the CA has told it when to try again), output a delay size in seconds, a
    newline, and a "cookie" value, and exit with status 5.  The daemon will try
    again after the specified amount of time has passed.