### PR TITLE
Cleanup for installing the project

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,7 @@ setup(
     ],
 
     data_files=[
-        ('/usr/local/libexec/certmonger', ['bin/cepces-submit']),
+        ('libexec/certmonger', ['bin/cepces-submit']),
     ],
 
     install_requires=[],


### PR DESCRIPTION
The configs should be copied by packagers if they want it or add it to the docs. The other data_files should repect the user specified prefix.