### PR TITLE
Username password keyring implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ local/
 
 .vscode/
 .venv/
+build/

--- a/conf/cepces.conf.dist
+++ b/conf/cepces.conf.dist
@@ -116,3 +116,14 @@ delegate=True
 #
 # Default: <not defined>
 #keyfile = /path/to/openssl-keyfile.pem
+
+[usernamepassword]
+# Use the following AD username in UPN notation.
+#
+# Default: <not defined>
+#username = user@your-ad.local
+ 
+# Use the following AD password.
+#
+# Default: <not defined>
+#password = ADpassword

--- a/conf/cepces.conf.dist
+++ b/conf/cepces.conf.dist
@@ -118,12 +118,18 @@ delegate=True
 #keyfile = /path/to/openssl-keyfile.pem
 
 [usernamepassword]
+# Name of service in default keyring item
+#
+# Default: <not defined>
+#keyring = cepces
+#
 # Use the following AD username in UPN notation.
 #
 # Default: <not defined>
 #username = user@your-ad.local
- 
+#
 # Use the following AD password.
+# Omit if using keyring
 #
 # Default: <not defined>
 #password = ADpassword

--- a/conf/cepces.conf.dist
+++ b/conf/cepces.conf.dist
@@ -118,18 +118,27 @@ delegate=True
 #keyfile = /path/to/openssl-keyfile.pem
 
 [usernamepassword]
+# Specify custom keyring service or use default.
+# Interactive prompt will be shown on default screen when username or
+# password is empty. Then a keyring item will be added with specified
+# credentials.
+#
 # Name of service in default keyring item
 #
-# Default: <not defined>
-#keyring = cepces
-#
+# Default: cepces
+#keyring_service = cepces
+
 # Use the following AD username in UPN notation.
+# When empty, interactive prompt is shown to save keyring item.
+# Should be then set in config.
 #
 # Default: <not defined>
 #username = user@your-ad.local
-#
+
 # Use the following AD password.
 # Omit if using keyring
+# If keyring item for username does not exist and both username and
+# password specified will be used.
 #
 # Default: <not defined>
 #password = ADpassword

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,8 @@ requires-python = ">=3.8"
 dependencies = [
     "cryptography >= 1.2",
     "requests",
-    "requests_gssapi >= 1.2.2"
+    "requests_gssapi >= 1.2.2",
+    "keyring"
 ]
 license = { file = "LICENSE" }
 authors = [

--- a/src/cepces/auth.py
+++ b/src/cepces/auth.py
@@ -127,10 +127,10 @@ class UsernamePasswordAuthenticationHandler(AuthenticationHandler):
         if keyring_service and username:
             try:
                 password = keyring.get_password(keyring_service, username)
-            except KeyringLocked as exc:
+            except KeyringLocked as e:
                 raise RuntimeError(
-                    'Keyring locked.',
-                ) from exc
+                    'Keyring locked. Can not unlock.',
+                ) from e
 
         return SOAPAuth.MessageUsernamePasswordAuthentication(
             username,

--- a/src/cepces/soap/__init__.py
+++ b/src/cepces/soap/__init__.py
@@ -18,8 +18,9 @@
 """Package for very rudimentary SOAP  handling."""
 from xml.etree.ElementTree import QName
 
-NS_SOAP = "http://www.w3.org/2003/05/soap-envelope"
-NS_ADDRESSING = "http://www.w3.org/2005/08/addressing"
+NS_SOAP = 'http://www.w3.org/2003/05/soap-envelope'
+NS_ADDRESSING = 'http://www.w3.org/2005/08/addressing'
+NS_WSSE = 'http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd'
 
 # ACTION_FAULT = 'http://www.w3.org/2005/08/addressing/fault'
 QNAME_FAULT = QName("http://www.w3.org/2003/05/soap-envelope", "Fault")

--- a/src/cepces/soap/__init__.py
+++ b/src/cepces/soap/__init__.py
@@ -21,6 +21,7 @@ from xml.etree.ElementTree import QName
 NS_SOAP = 'http://www.w3.org/2003/05/soap-envelope'
 NS_ADDRESSING = 'http://www.w3.org/2005/08/addressing'
 NS_WSSE = 'http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd'
+NS_WSU = 'http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd'
 
 # ACTION_FAULT = 'http://www.w3.org/2005/08/addressing/fault'
 QNAME_FAULT = QName("http://www.w3.org/2003/05/soap-envelope", "Fault")

--- a/src/cepces/soap/auth.py
+++ b/src/cepces/soap/auth.py
@@ -27,6 +27,7 @@ from cepces import Base
 from cepces.krb5 import types as ktypes
 from cepces.krb5.core import Context, Keytab, Principal
 from cepces.krb5.core import CredentialOptions, Credentials, CredentialCache
+from cepces.soap.types import Security as WSSecurity, UsernameToken
 
 
 class Authentication(Base, metaclass=ABCMeta):
@@ -166,7 +167,13 @@ class MessageUsernamePasswordAuthentication(Authentication):
         return None
 
     def post_process(self, envelope):
-        raise NotImplementedError()
+        envelope.header.element.append(WSSecurity.create())
+
+        envelope.header.security.element.append(UsernameToken.create())
+        envelope.header.security.usernametoken.username = self._username
+        envelope.header.security.usernametoken.password = self._password
+
+        return envelope
 
 
 class TransportCertificateAuthentication(Authentication):

--- a/src/cepces/soap/auth.py
+++ b/src/cepces/soap/auth.py
@@ -21,6 +21,9 @@
 """This module contains SOAP related authentication."""
 from abc import ABCMeta, abstractmethod, abstractproperty
 import os
+import base64
+import hashlib
+from datetime import datetime
 import gssapi
 from requests_gssapi import HTTPSPNEGOAuth
 from cepces import Base
@@ -155,8 +158,22 @@ class MessageUsernamePasswordAuthentication(Authentication):
 
     def __init__(self, username, password):
         super().__init__()
-        self._username = username
-        self._password = password
+        self._username: str = username
+        self._password: str = password
+        self._init_digest()
+
+    def _init_digest(self):
+        self._created = datetime.now()
+        raw_nonce = f"{self._username}:{self._password}:{self._created}"
+        self._nonce = hashlib.md5(raw_nonce.encode("utf-8")).digest()
+
+        # m = hashlib.sha1()
+        # m.update(self._nonce)
+        # m.update(self._created.strftime("%Y-%m-%dT%H:%M:%SZ").encode("utf-8"))
+        # m.update(self._password.encode("utf-8"))
+        # self._password = base64.b64encode(m.digest()).decode("utf-8")
+
+        self._nonce = base64.b64encode(self._nonce).decode("utf-8")
 
     @property
     def transport(self):
@@ -172,6 +189,9 @@ class MessageUsernamePasswordAuthentication(Authentication):
         envelope.header.security.element.append(UsernameToken.create())
         envelope.header.security.usernametoken.username = self._username
         envelope.header.security.usernametoken.password = self._password
+        # envelope.header.security.usernametoken.password = self._password_digest
+        envelope.header.security.usernametoken.nonce = self._nonce
+        envelope.header.security.usernametoken.created = self._created
 
         return envelope
 

--- a/src/cepces/soap/types.py
+++ b/src/cepces/soap/types.py
@@ -21,10 +21,10 @@
 # pylint: disable=invalid-name
 """This module contains common SOAP types."""
 from xml.etree.ElementTree import Element, QName
-from cepces.soap import NS_ADDRESSING, NS_SOAP, NS_WSSE
+from cepces.soap import NS_ADDRESSING, NS_SOAP, NS_WSSE, NS_WSU
 from cepces.xml import NS_XSI
 from cepces.xml.binding import XMLElement, XMLNode, XMLValue
-from cepces.xml.converter import StringConverter
+from cepces.xml.converter import StringConverter, DateTimeConverter
 
 
 class FaultSubcode(XMLNode):
@@ -101,6 +101,12 @@ class UsernameToken(XMLNode):
     password = XMLValue(
         'Password', converter=StringConverter, namespace=NS_WSSE
     )
+    nonce = XMLValue(
+        'Nonce', converter=StringConverter, namespace=NS_WSSE
+    )
+    created = XMLValue(
+        'Created', converter=DateTimeConverter, namespace=NS_WSU
+    )
 
     @staticmethod
     def create():
@@ -111,7 +117,14 @@ class UsernameToken(XMLNode):
 
         password = Element(QName(NS_WSSE, 'Password'))
         password.attrib[QName(NS_WSSE, 'Type' )] = 'http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-username-token-profile-1.0#PasswordText'
+        # password.attrib[QName(NS_WSSE, 'Type' )] = 'http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-username-token-profile-1.0#PasswordDigest'
         usernametoken.append(password)
+        
+        nonce = Element(QName(NS_WSSE, 'Nonce'))
+        usernametoken.append(nonce)
+        
+        created = Element(QName(NS_WSU, 'Created'))
+        usernametoken.append(created)
 
         return usernametoken
 

--- a/src/cepces/soap/types.py
+++ b/src/cepces/soap/types.py
@@ -21,7 +21,7 @@
 # pylint: disable=invalid-name
 """This module contains common SOAP types."""
 from xml.etree.ElementTree import Element, QName
-from cepces.soap import NS_ADDRESSING, NS_SOAP
+from cepces.soap import NS_ADDRESSING, NS_SOAP, NS_WSSE
 from cepces.xml import NS_XSI
 from cepces.xml.binding import XMLElement, XMLNode, XMLValue
 from cepces.xml.converter import StringConverter
@@ -92,6 +92,45 @@ class Fault(XMLNode):
         return element
 
 
+class UsernameToken(XMLNode):
+    """WSSE UsernameToken."""
+
+    username = XMLValue(
+        'Username', converter=StringConverter, namespace=NS_WSSE
+    )
+    password = XMLValue(
+        'Password', converter=StringConverter, namespace=NS_WSSE
+    )
+
+    @staticmethod
+    def create():
+        usernametoken = Element(QName(NS_WSSE, 'UsernameToken'))
+
+        username = Element(QName(NS_WSSE, 'Username'))
+        usernametoken.append(username)
+
+        password = Element(QName(NS_WSSE, 'Password'))
+        password.attrib[QName(NS_WSSE, 'Type' )] = 'http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-username-token-profile-1.0#PasswordText'
+        usernametoken.append(password)
+
+        return usernametoken
+
+
+class Security(XMLNode):
+    """WSSE Security."""
+
+    usernametoken = XMLElement(
+        'UsernameToken', binder=UsernameToken, namespace=NS_WSSE
+    )
+
+    @staticmethod
+    def create():
+        security = Element(QName(NS_WSSE, 'Security'))
+        security.attrib[QName(NS_SOAP, 'mustUnderstand')] = '1'
+
+        return security
+
+
 class Header(XMLNode):
     """SOAP Header."""
 
@@ -109,6 +148,10 @@ class Header(XMLNode):
 
     relates_to = XMLValue(
         "RelatesTo", converter=StringConverter, namespace=NS_ADDRESSING, nillable=True
+    )
+
+    security =  XMLElement (
+        'Security', binder=Security, namespace=NS_WSSE
     )
 
     @staticmethod


### PR DESCRIPTION
Hello Everyone
Did not know how to push commits to @hansjoachimknobloch pull request https://github.com/openSUSE/cepces/pull/9
So I merged this PR and added system defaults keyring usage.
You can store password in default keyring. 

It works flawessly with --session parameter for getcert operations for current user.
Added also interactively window using zenity on default screen to enter credentials when they are not found and saves them in keyring.

Auto renewal does not work when there is d-bus session locked (no logged in active user in session). When there is active unlocked d-bus session autorenewal using keyring credentials works.
There is fallback to password from file when keyring item (username) and password is specified but not existent in keyring.

I also added Created and Nonce headers to SOAP request.
Tried authenticating with PasswordDigest instead of PasswordText according to documentation but not succeed.
https://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-username-token-profile-1.0.pdf
Any help generating digest appreciated.
