### PR TITLE
fix `ccache` conf bool parsing

### DIFF
--- a/src/cepces/auth.py
+++ b/src/cepces/auth.py
@@ -66,7 +66,7 @@ class KerberosAuthenticationHandler(AuthenticationHandler):
 
         keytab = section.get("keytab", None)
         realm = section.get("realm", None)
-        ccache = section.get("ccache", True)
+        ccache = strtobool(section.get("ccache", True))
         principals = section.get("principals", "")
         enctypes = section.get("enctypes", "")
         delegate = strtobool(section.get("delegate", True))


### PR DESCRIPTION
`ccache` is currently always assumed as `True`, even if `False` is set in the config file since the string is not converted to bool.