### PR TITLE
fix(soap): Encode keytab path to bytes for GSSAPI store

### DIFF
--- a/src/cepces/soap/auth.py
+++ b/src/cepces/soap/auth.py
@@ -124,7 +124,7 @@ class TransportGSSAPIAuthentication(Authentication):
             keytab = get_default_keytab_name()
 
         store = {
-            b"client_keytab": keytab,
+            b"client_keytab": keytab.encode("utf-8"),
             # This doesn't work, we need to set KRB5CCNAME
             # b"ccache": "MEMORY:cepces",
         }

--- a/tests/cepces_test/soap/test_auth.py
+++ b/tests/cepces_test/soap/test_auth.py
@@ -197,10 +197,6 @@ class TestTransportGSSAPIAuthentication:
                 init_ccache=False
             )
 
-    @pytest.mark.xfail(
-        reason="keytab path must be encoded to bytes before passing to store",
-        strict=True,
-    )
     @patch("cepces.soap.auth.Context")
     @patch("cepces.soap.auth.Principal")
     @patch("cepces.soap.auth.get_default_keytab_name")


### PR DESCRIPTION
Encode keytab path to bytes for GSSAPI store.