### PR TITLE
fix: proposal of better error handling in case the result object is not set

### DIFF
--- a/src/cepces/certmonger/operation.py
+++ b/src/cepces/certmonger/operation.py
@@ -124,6 +124,10 @@ class Submit(Operation):
 
         self._logger.debug("Result is: %s", result)
 
+        if result is None:
+            self._logger.error("Result is None, maybe you add an issue finding list of endpoint")
+            return CertmongerResult.CONNECTERROR
+
         # If we have a certificate, return it. Otherwise, ask certmonger to
         # wait a bit.
         if result.token:


### PR DESCRIPTION
Hi I hit an issue where my CEP endpoint is giving me an empty list
```
2025-12-17 17:48:11,942 cepces.xcep.service.Service<0x7fb4dedbd210>:debug:Received message: 
b'''
<ns0:GetPoliciesResponse xmlns:ns0="http://schemas.microsoft.com/windows/pki/2009/01/enrollmentpolicy" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
    <ns0:response>
        <ns0:policyID>{F803BF1A-EB36-42A4-973C-AF4555EB8782}</ns0:policyID>
        <ns0:policyFriendlyName>My PKI</ns0:policyFriendlyName>
        <ns0:nextUpdateHours>1</ns0:nextUpdateHours>
        <ns0:policiesNotChanged xsi:nil="true" />
        <ns0:policies xsi:nil="true" />
    </ns0:response>
    <ns0:cAs xsi:nil="true" />
    <ns0:oIDs xsi:nil="true" />
</ns0:GetPoliciesResponse>
```

in this situation the request is send to nowhere resulting in an None value for result

Maybe it is not the best place to handle this, I'm keen to improve this MR if I receive guidance ;) 