### PR TITLE
fix: Set default client/server version to 0 instead of null for compatibiltiy

### DIFF
--- a/src/cepces/xcep/types.py
+++ b/src/cepces/xcep/types.py
@@ -102,7 +102,7 @@ class RequestFilter(XMLNode):
         # 6: Current schema (Windows 10/11, Server 2019/2022/2025)
         # Full detail: template properties, issuance requirements, key usage, renewal policies, and advanced flags.
         client_version = Element(QName(NS_CEP, "clientVersion"))  # type: ignore[type-var]  # noqa: E501
-        client_version.text = "6"
+        client_version.text = "0"
         element.append(client_version)
 
         # 0: No specific server schema version required


### PR DESCRIPTION
Fixing #74 

This will change default value for client/server version from null to 0 for compatibility

It is better to sent by default 0 as client/server version like this instead of null, then CEP will interpret it like this:

serverVersion=0 -> I don’t require the server to advertise a specific schema version
clientVersion=0 -> I don’t support schema negotiation (legacy, minimal)