### PR TITLE
fix(selinux): allow certmonger_t to search sysctl_net_t directories

### DIFF
--- a/selinux/cepces.te
+++ b/selinux/cepces.te
@@ -4,6 +4,7 @@ require {
     type certmonger_t;
     type kernel_t;
     type ldconfig_exec_t;
+    type sysctl_net_t;
 }
 
 type cepces_log_t;
@@ -13,4 +14,5 @@ allow certmonger_t cepces_log_t:dir { add_name search write };
 allow certmonger_t cepces_log_t:file { create open };
 
 allow certmonger_t kernel_t:system module_request;
+allow certmonger_t sysctl_net_t:dir search;
 allow certmonger_t ldconfig_exec_t:file { read execute open execute_no_trans };

--- a/tests/cepces_test/soap/test_auth.py
+++ b/tests/cepces_test/soap/test_auth.py
@@ -368,7 +368,7 @@ class TestTransportGSSAPIAuthentication:
     @patch("cepces.soap.auth.gssapi.Name")
     @patch("cepces.soap.auth.gssapi.Credentials")
     @patch("cepces.soap.auth.HTTPSPNEGOAuth")
-    @patch("cepces.soap.auth.os.environ", {})
+    @patch("cepces.soap.auth.os.environ", dict[str, str]())
     def test_init_ccache_sets_environment_variable(
         self,
         mock_http_spnego: MagicMock,


### PR DESCRIPTION
Python's socket/network initialization reads /proc/sys/net, which is labeled sysctl_net_t. Without the search permission certmonger denies the openat syscall with EACCES under enforcing SELinux.