### PR TITLE
fix(config): escape \$ in CLI overrides to avoid interpolation errors

### DIFF
--- a/src/cepces/config.py
+++ b/src/cepces/config.py
@@ -267,10 +267,10 @@ class Configuration(Base):
         # Override globals set from the command line
         if global_overrides is not None:
             for key, val in global_overrides.items():
-                config["global"][key] = val
+                config["global"][key] = val.replace("$", "$$")
         if krb5_overrides is not None:
             for key, val in krb5_overrides.items():
-                config["kerberos"][key] = val
+                config["kerberos"][key] = val.replace("$", "$$")
 
         return Configuration.from_parser(config)
 


### PR DESCRIPTION
ConfigParser with ExtendedInterpolation rejects bare \$ characters (e.g. machine account principals like VM1\$@TEST.LOCAL) with a ValueError. Escape \$ as \$\$ before writing override values so ExtendedInterpolation unescapes them correctly on read.

Fixes: #27