### PR TITLE
feat(core): retry all CES endpoints on connection failure

### DIFF
--- a/src/cepces/certmonger/operation.py
+++ b/src/cepces/certmonger/operation.py
@@ -30,6 +30,7 @@ if TYPE_CHECKING:
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import serialization
 from cryptography.x509.oid import NameOID
+import requests
 from cepces import __title__, __version__
 from cepces import Base
 from cepces.core import PartialChainError
@@ -137,6 +138,10 @@ class Submit(Operation):
             print(error, file=self._out)
 
             return CertmongerResult.REJECTED
+        except requests.exceptions.RequestException as error:
+            print(error, file=self._out)
+
+            return CertmongerResult.CONNECTERROR
 
         if result is None:
             self._logger.error(
@@ -190,6 +195,10 @@ class Poll(Operation):
             print(error, file=self._out)
 
             return CertmongerResult.REJECTED
+        except requests.exceptions.RequestException as error:
+            print(error, file=self._out)
+
+            return CertmongerResult.CONNECTERROR
 
         if result is None:
             self._logger.error("No result received from poll")

--- a/src/cepces/core.py
+++ b/src/cepces/core.py
@@ -226,28 +226,35 @@ class Service(Base):
         self, csr: x509.CertificateSigningRequest, renew: bool = False
     ) -> "WSTEPService.Response | None":
         """Request a certificate with a CSR through a CEP endpoint."""
-        endpoint = None
+        candidates = [
+            ep
+            for ep in (self.endpoints or [])
+            if renew and ep.renewal_only or not ep.renewal_only
+        ]
 
-        for candidate in self.endpoints or []:
-            # If not renewing and the endpoint only supports renewal, ignore
-            # it.
-            if renew and candidate.renewal_only or not candidate.renewal_only:
-                endpoint = candidate
-
-                break
-
-        # No endpoint found.
-        if not endpoint:
+        if not candidates:
             return None
 
-        self._ces = WSTEPService(
-            endpoint=str(endpoint),
-            auth=self._config.auth,
-            capath=self._config.cas,
-            openssl_ciphers=self._config.openssl_ciphers,
-        )
+        last_error: requests.exceptions.RequestException | None = None
 
-        return self._request_ces(csr)
+        for endpoint in candidates:
+            self._logger.debug("Trying CES endpoint: %s", endpoint.url)
+            self._ces = WSTEPService(
+                endpoint=str(endpoint),
+                auth=self._config.auth,
+                capath=self._config.cas,
+                openssl_ciphers=self._config.openssl_ciphers,
+            )
+            try:
+                return self._request_ces(csr)
+            except requests.exceptions.RequestException as e:
+                last_error = e
+                self._logger.warning(
+                    "CES endpoint %s failed: %s", endpoint.url, e
+                )
+
+        assert last_error is not None
+        raise last_error
 
     def request(
         self, csr: x509.CertificateSigningRequest, renew: bool = False

--- a/tests/cepces_test/certmonger/test_operation.py
+++ b/tests/cepces_test/certmonger/test_operation.py
@@ -26,6 +26,7 @@ from cryptography import x509
 from cryptography.hazmat.backends import default_backend
 from cryptography.x509.oid import NameOID
 import io
+import requests.exceptions
 
 
 def test_get_default_template_call() -> None:
@@ -560,6 +561,72 @@ J9R2yTmwnWuSjm3k2/QOKOKYb+fO0iYXqCKeP4P7s4jGi02A5Q==
         result = operation()
 
         assert result == CertmongerResult.UNDERCONFIGURED
+
+
+def test_submit_returns_connecterror_on_request_exception() -> None:
+    """Tests that Submit returns CONNECTERROR when a connection error
+    occurs."""
+    import os
+
+    with patch.dict(
+        os.environ,
+        {
+            "CERTMONGER_CSR": """-----BEGIN CERTIFICATE REQUEST-----
+MIIDgTCCAmkCAQAwEjEQMA4GA1UEAxMHZmVkb3JhMjCCASIwDQYJKoZIhvcNAQEB
+BQADggEPADCCAQoCggEBALhuaeeiXhuMyqCOWVpBeFBY+QqVKVWDz6tvW704uXOq
+/XxZDD4CGJEVNvuV3hRFhiHMiUoAKiqQYXSJ307sdfosLfhZllHmzB1G1AUbw3Le
+UnB7itt3KX8DdPeenpYo9GuUUCnv3rGzCCAHutFMwboI0FEmUQ+N0YrHc2K4kWFp
+CCdvVGsYCAyE3svdCMNcX1tDm9F4JG7oFkmyTxZunSPMXTBrqW/BiZJj5CcqHq54
+F56vsUeLnTnd6oapyOIpKH8yOFPpC6ckuTFg2kgzeV+5fDAYfA8yGB6HwKeFCSKx
++ziZFQ5uzBsZgCnTd246LrCogiGNULyYwghaCvPoF38CAwEAAaCCASgwKwYJKoZI
+hvcNAQkUMR4eHAAyADAAMgA1ADEAMgAxADkAMAA2ADMAMwAwADkwgfgGCSqGSIb3
+DQEJDjGB6jCB5zCBgwYDVR0RBHwweoIHZmVkb3JhMqAvBgorBgEEAYI3FAIDoCEM
+H2hvc3QvZmVkb3JhMkBNQVJTLk1JTEtZV0FZLlNJVEWgPgYGKwYBBQICoDQwMqAU
+GxJNQVJTLk1JTEtZV0FZLlNJVEWhGjAYoAMCAQGhETAPGwRob3N0GwdmZWRvcmEy
+MBMGA1UdJQQMMAoGCCsGAQUFBwMBMAwGA1UdEwEB/wQCMAAwHQYDVR0OBBYEFEqI
+6jUIxqWQa0dElUmEzCgLpAX2MB0GCSsGAQQBgjcUAgQQHg4ATQBhAGMAaABpAG4A
+ZTANBgkqhkiG9w0BAQsFAAOCAQEAUKbuBaz9KtrbJ2TQ8UvMdRaNR7X1O6diZPcu
+UsNrw5W6eJX2LBdTcjxWCrB9oF6qwzNiGH2Kt79JkQoMSqAm0AoLJ1hBGN+e8ano
+ljR8NrQkLVnbsQMGKWrCjB7r5ycT42iH32foxwb1FaA5/mM05PQZ/syVFLyfjJLr
+IfGoQKCCi4nqcho+Ukfxa7i3ESoWuynVnqJzKOXnxie5/VHbNVVCJ372Kk3FbT3Z
+oMTDsPOVy3/SVhjVVl8eWs/ch6mJpnRlkkriOC1aQo/P606hCb+7+l9cc/31ENJj
+J9R2yTmwnWuSjm3k2/QOKOKYb+fO0iYXqCKeP4P7s4jGi02A5Q==
+-----END CERTIFICATE REQUEST-----
+"""
+        },
+    ):
+        mock_service = Mock()
+        mock_service.request.side_effect = requests.exceptions.ConnectionError(
+            "Connection refused"
+        )
+
+        out = io.StringIO()
+        operation = CertmongerOperations.Submit(mock_service, out=out)
+        result = operation()
+
+        assert result == CertmongerResult.CONNECTERROR
+        assert "Connection refused" in out.getvalue()
+
+
+def test_poll_returns_connecterror_on_request_exception() -> None:
+    """Tests that Poll returns CONNECTERROR when a connection error occurs."""
+    import os
+
+    with patch.dict(
+        os.environ,
+        {"CERTMONGER_CA_COOKIE": "27,https://ces1.example.com/CES"},
+    ):
+        mock_service = Mock()
+        mock_service.poll.side_effect = requests.exceptions.ConnectionError(
+            "Connection refused"
+        )
+
+        out = io.StringIO()
+        operation = CertmongerOperations.Poll(mock_service, out=out)
+        result = operation()
+
+        assert result == CertmongerResult.CONNECTERROR
+        assert "Connection refused" in out.getvalue()
 
 
 def test_operations_needs_service_attribute() -> None:

--- a/tests/cepces_test/test_core.py
+++ b/tests/cepces_test/test_core.py
@@ -19,7 +19,8 @@ import datetime
 import unittest
 import logging
 from xml.etree import ElementTree
-from unittest.mock import Mock, patch
+from unittest.mock import Mock, patch, PropertyMock
+import requests.exceptions
 from cryptography import x509
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import hashes, serialization
@@ -27,6 +28,7 @@ from cryptography.hazmat.primitives.asymmetric import rsa
 from cryptography.x509.oid import AuthorityInformationAccessOID, NameOID
 from cepces import Base
 from cepces.core import Service
+from cepces.soap.service import SOAPFault
 from cepces.xcep.types import GetPoliciesResponse
 
 # GetPoliciesResponse with nil policies and CAs (no enrollment available)
@@ -378,3 +380,158 @@ def test_resolve_chain_aia_with_der_response():
     assert len(result) == 2
     assert result[0].subject == leaf_cert.subject
     assert result[1].subject == root_cert.subject
+
+
+# ---------------------------------------------------------------------------
+# _request_cep failover tests
+# ---------------------------------------------------------------------------
+
+
+def _make_service_for_failover():
+    """Return a Service in Policy mode without mocking endpoints."""
+    mock_config = Mock()
+    mock_config.endpoint_type = "Policy"
+    mock_config.endpoint = "https://example.com/CEP"
+    mock_config.auth = Mock()
+    mock_config.cas = None
+    mock_config.openssl_ciphers = None
+
+    with (
+        patch("cepces.core.XCEPService") as mock_xcep_class,
+        patch("cepces.core.create_session"),
+    ):
+        mock_xcep = Mock()
+        mock_xcep.get_policies.return_value = Mock()
+        mock_xcep_class.return_value = mock_xcep
+
+        service = Service(mock_config)
+
+    return service, mock_config
+
+
+def _make_endpoint(url: str) -> Mock:
+    ep = Mock()
+    ep.url = url
+    ep.renewal_only = False
+    return ep
+
+
+def test_request_cep_failover_to_second_endpoint():
+    """_request_cep retries the next endpoint when the first fails."""
+    service, _mock_config = _make_service_for_failover()
+
+    ep1 = _make_endpoint("https://ces1.example.com/CES")
+    ep2 = _make_endpoint("https://ces2.example.com/CES")
+    mock_response = Mock()
+
+    connection_error = requests.exceptions.ConnectionError("refused")
+
+    with (
+        patch.object(
+            type(service), "endpoints", new_callable=PropertyMock
+        ) as mock_endpoints,
+        patch.object(service, "_request_ces") as mock_request_ces,
+    ):
+        mock_endpoints.return_value = [ep1, ep2]
+        mock_request_ces.side_effect = [connection_error, mock_response]
+
+        result = service._request_cep(Mock())
+
+    assert result is mock_response
+    assert mock_request_ces.call_count == 2
+
+
+def test_request_cep_all_endpoints_fail():
+    """_request_cep re-raises the last exception when all endpoints fail."""
+    service, _mock_config = _make_service_for_failover()
+
+    ep1 = _make_endpoint("https://ces1.example.com/CES")
+    ep2 = _make_endpoint("https://ces2.example.com/CES")
+
+    error1 = requests.exceptions.ConnectionError("refused ces1")
+    error2 = requests.exceptions.ConnectionError("refused ces2")
+
+    with (
+        patch.object(
+            type(service), "endpoints", new_callable=PropertyMock
+        ) as mock_endpoints,
+        patch.object(service, "_request_ces") as mock_request_ces,
+    ):
+        mock_endpoints.return_value = [ep1, ep2]
+        mock_request_ces.side_effect = [error1, error2]
+
+        raised = None
+        try:
+            service._request_cep(Mock())
+        except requests.exceptions.ConnectionError as e:
+            raised = e
+
+    assert raised is error2
+    assert mock_request_ces.call_count == 2
+
+
+def test_request_cep_soap_fault_does_not_failover():
+    """_request_cep propagates SOAPFault without trying next endpoint."""
+    service, _mock_config = _make_service_for_failover()
+
+    ep1 = _make_endpoint("https://ces1.example.com/CES")
+    ep2 = _make_endpoint("https://ces2.example.com/CES")
+
+    mock_fault = Mock()
+    mock_fault.code.value = "env:Receiver"
+    mock_fault.code.subcode = None
+    mock_fault.reason.text = "Request denied"
+
+    with (
+        patch.object(
+            type(service), "endpoints", new_callable=PropertyMock
+        ) as mock_endpoints,
+        patch.object(service, "_request_ces") as mock_request_ces,
+    ):
+        mock_endpoints.return_value = [ep1, ep2]
+        mock_request_ces.side_effect = SOAPFault(mock_fault)
+
+        raised = None
+        try:
+            service._request_cep(Mock())
+        except SOAPFault as e:
+            raised = e
+
+    assert raised is not None
+    assert mock_request_ces.call_count == 1
+
+
+def test_request_cep_single_endpoint_success():
+    """_request_cep returns the response when the single endpoint succeeds."""
+    service, _mock_config = _make_service_for_failover()
+
+    ep = _make_endpoint("https://ces1.example.com/CES")
+    mock_response = Mock()
+
+    with (
+        patch.object(
+            type(service), "endpoints", new_callable=PropertyMock
+        ) as mock_endpoints,
+        patch.object(service, "_request_ces") as mock_request_ces,
+    ):
+        mock_endpoints.return_value = [ep]
+        mock_request_ces.return_value = mock_response
+
+        result = service._request_cep(Mock())
+
+    assert result is mock_response
+    assert mock_request_ces.call_count == 1
+
+
+def test_request_cep_no_endpoints_returns_none():
+    """_request_cep returns None when no endpoints match."""
+    service, _mock_config = _make_service_for_failover()
+
+    with patch.object(
+        type(service), "endpoints", new_callable=PropertyMock
+    ) as mock_endpoints:
+        mock_endpoints.return_value = []
+
+        result = service._request_cep(Mock())
+
+    assert result is None


### PR DESCRIPTION
When operating in Policy mode, _request_cep() now iterates through all matching CES endpoints in priority order instead of stopping at the first. A requests.exceptions.RequestException (connection refused, timeout, etc.) triggers a warning log and a retry on the next endpoint; SOAPFault still propagates immediately since the server deliberately rejected the request. If all endpoints fail, the last exception is re-raised.

certmonger's Submit and Poll operations now catch RequestException and return CONNECTERROR (exit code 3) so certmonger receives proper feedback when all servers are unreachable.

Fixes #35